### PR TITLE
Include fonts in package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,6 @@ setup(
     ],
     packages=find_packages(exclude=('tests',)),
     include_package_data=True,
+    package_data={'flask_simple_captcha': ['fonts/*']},
     install_requires=['Werkzeug<3,>=0.16.0', 'Pillow>4, <10', 'pyjwt<3,>=2'],
 )


### PR DESCRIPTION
... currently installing this project with pip does not include the fonts, resulting in an error during captcha generation (calling choice on an empty list of font files)